### PR TITLE
Register schema without remote context object

### DIFF
--- a/scripts/register_schemas.py
+++ b/scripts/register_schemas.py
@@ -6,6 +6,7 @@ import requests
 from decouple import config
 from typing import List
 from typing import Dict
+from pyld import jsonld
 
 # TOKEN has to be set
 # in file .env (project root): TOKEN="..."
@@ -53,9 +54,10 @@ for schema_name in order:
     f.close()
 
     # remove remote context
-    orig_context = schema['@context']
-    schema['@context'] = orig_context[1]
+    #orig_context = schema['@context']
+    #schema['@context'] = orig_context[1]
 
-    create_schema(schema)
+    # resolve all IRIs and get rid of remote schema
+    create_schema(jsonld.compact(schema, {}))
 
 

--- a/scripts/register_schemas.py
+++ b/scripts/register_schemas.py
@@ -53,11 +53,7 @@ for schema_name in order:
     schema = json.load(f)
     f.close()
 
-    # remove remote context
-    #orig_context = schema['@context']
-    #schema['@context'] = orig_context[1]
-
-    # resolve all IRIs and get rid of remote schema
+    # expand all prefixes and get rid of remote schema
     create_schema(jsonld.compact(schema, {}))
 
 


### PR DESCRIPTION
Instead of using a remote context object in the SHACL shape definition, expand it before registration. 

relates to https://github.com/BlueBrain/nexus/issues/3085

https://github.com/BlueBrain/nexus/issues/3085#issuecomment-1046688888