### PR TITLE
Include MonetaryAmount's properties

### DIFF
--- a/compositeviews/compositeview01/composite_view.json
+++ b/compositeviews/compositeview01/composite_view.json
@@ -13,7 +13,7 @@
     {
       "@id": "connectome-sparql-projection-01",
       "@type": "SparqlProjection",
-      "query": "PREFIX nxv: <https://bluebrain.github.io/nexus/vocabulary/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> CONSTRUCT { {resource_id} ?p ?o . } WHERE { {resource_id} ?p ?o . FILTER(!strstarts(str(?p),str(nxv:)) && ?o != \"validate\"^^xsd:string && ?o != \"validate@validate.com\"^^xsd:string && ?o != <http://schema.org/Thing>) }",
+      "query": "PREFIX nxv: <https://bluebrain.github.io/nexus/vocabulary/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> CONSTRUCT { {resource_id} ?p ?o . ?amount ?ap ?ao . } WHERE { {resource_id} ?p ?o . FILTER(!strstarts(str(?p),str(nxv:)) && ?o != \"validate\"^^xsd:string && ?o != \"validate@validate.com\"^^xsd:string && ?o != <http://schema.org/Thing>) . OPTIONAL { {resource_id} a <http://schema.org/MonetaryGrant> ; <http://schema.org/amount> ?amount . ?amount ?ap ?ao . }}",
       "includeMetadata": false,
       "includeDeprecated": false
     }

--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -16,6 +16,10 @@
         "copy_to": "_all_fields",
         "type": "text"
       },
+      "keywords": {
+        "copy_to": "_all_fields",
+        "type": "text"
+      },
       "description": {
         "copy_to": "_all_fields",
         "type": "text"


### PR DESCRIPTION
`schema:MonetaryAmount` is connected to `schema:MonetaryGrant` via `schema:amount` and is a blank node, hence it does not match Delta's template `{resource_id}`.
As a consequence, `schema:MonetaryAmount`s properties were missing in the SPARQL projection.

This PR adds an `Optional` clause to fix this.