### PR TITLE
Composite View: Adapt ES index

### DIFF
--- a/compositeviews/compositeview01/composite_view.json
+++ b/compositeviews/compositeview01/composite_view.json
@@ -9,7 +9,7 @@
   ],
   "projections": [
     "researchproject.json",
-    "dataset.json",
+    "dataset-scholarlyarticle.json",
     {
       "@id": "connectome-sparql-projection-01",
       "@type": "SparqlProjection",

--- a/compositeviews/compositeview01/dataset-scholarlyarticle.json
+++ b/compositeviews/compositeview01/dataset-scholarlyarticle.json
@@ -1,5 +1,5 @@
 {
-  "@id": "connectome-es-projection-dataset-01",
+  "@id": "connectome-es-projection-dataset-scholarlyarticle-01",
   "@type": "ElasticSearchProjection",
   "mapping": {
     "dynamic": false,
@@ -198,7 +198,8 @@
     }
   },
   "resourceTypes": [
-    "http://schema.org/Dataset"
+    "http://schema.org/Dataset",
+    "http://schema.org/ScholarlyArticle"
   ],
   "includeMetadata": false
 }

--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -111,7 +111,9 @@
         "type": "search_as_you_type"
       },
       "_all_fields": {
-        "copy_to": "_all_fields",
+        "type": "text"
+      },
+      "_keywords": {
         "type": "text"
       }
     }

--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -107,6 +107,9 @@
         },
         "type": "nested"
       },
+      "_sayt": {
+        "type": "search_as_you_type"
+      },
       "_all_fields": {
         "copy_to": "_all_fields",
         "type": "text"

--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -13,11 +13,44 @@
         "type": "keyword"
       },
       "name": {
-        "copy_to": "_all_fields",
+        "copy_to": [
+          "_all_fields",
+          "_sayt"
+        ],
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          },
+          "reverse": {
+            "analyzer": "reverse",
+            "type": "text"
+          },
+          "trigram": {
+            "analyzer": "trigram",
+            "type": "text"
+          }
+        },
+        "term_vector": "with_positions_offsets",
         "type": "text"
       },
       "keywords": {
-        "copy_to": "_all_fields",
+        "copy_to": "_keywords",
+        "type": "text"
+      },
+      "keywords_en": {
+        "copy_to": "_keywords",
+        "type": "text"
+      },
+      "keywords_de": {
+        "copy_to": "_keywords",
+        "type": "text"
+      },
+      "keywords_fr": {
+        "copy_to": "_keywords",
+        "type": "text"
+      },
+      "keywords_it": {
+        "copy_to": "_keywords",
         "type": "text"
       },
       "description": {

--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -73,6 +73,26 @@
         "copy_to": "_all_fields",
         "type": "text"
       },
+      "abstract": {
+        "copy_to": "_all_fields",
+        "type": "text"
+      },
+      "abstract_en": {
+        "copy_to": "_all_fields",
+        "type": "text"
+      },
+      "abstract_de": {
+        "copy_to": "_all_fields",
+        "type": "text"
+      },
+      "abstract_fr": {
+        "copy_to": "_all_fields",
+        "type": "text"
+      },
+      "abstract_it": {
+        "copy_to": "_all_fields",
+        "type": "text"
+      },
       "member": {
         "properties": {
           "name": {
@@ -117,6 +137,38 @@
     },
     "description_it": {
       "@id": "description",
+      "@language": "it"
+    },
+    "abstract_en": {
+      "@id": "abstract",
+      "@language": "en"
+    },
+    "abstract_de": {
+      "@id": "abstract",
+      "@language": "de"
+    },
+    "abstract_fr": {
+      "@id": "abstract",
+      "@language": "fr"
+    },
+    "abstract_it": {
+      "@id": "abstract",
+      "@language": "it"
+    },
+    "keywords_en": {
+      "@id": "keywords",
+      "@language": "en"
+    },
+    "keywords_de": {
+      "@id": "keywords",
+      "@language": "de"
+    },
+    "keywords_fr": {
+      "@id": "keywords",
+      "@language": "fr"
+    },
+    "keywords_it": {
+      "@id": "keywords",
       "@language": "it"
     },
     "url": {


### PR DESCRIPTION
Adaptions of ES index:

- dataset: I figured that the ES projection for dataset and scholarly article can be unified for now since they both stem from creative work.
- research project:
   - I added "_sayt" to the ES field defs.
   - I added the ES search-as-you type config for the `name` prop.
   - `abstract` prop was added to the ES index
  
For both projections, there is now a field `_keywords` which contains the keywords of **all** languages. Language tags are contained in JSON-LD context, the convention being: `keywords` (no language tag), keyword_en for English language tags, same for "de", "fr", and "it".