### PR TITLE
Fix ES mapping for askReco

### DIFF
--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -156,7 +156,7 @@
         "type": "search_as_you_type"
       },
       "_abstract": {
-        "type": "text",
+        "type": "text"
       },
       "_all_fields": {
         "type": "text"

--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -155,6 +155,9 @@
       "_sayt": {
         "type": "search_as_you_type"
       },
+      "_abstract": {
+        "type": "text",
+      },
       "_all_fields": {
         "type": "text"
       },

--- a/compositeviews/compositeview01/researchproject.json
+++ b/compositeviews/compositeview01/researchproject.json
@@ -12,6 +12,41 @@
         "copy_to": "_all_fields",
         "type": "keyword"
       },
+      "author": {
+        "properties": {
+          "@id": {
+            "copy_to": [
+              "_all_fields",
+              "_author_ids",
+              "_sayt"
+            ],
+            "type": "keyword"
+          },
+          "name": {
+            "copy_to": [
+              "_all_fields",
+              "_sayt",
+              "_authors"
+            ],
+            "fields": {
+              "raw": {
+                "type": "keyword"
+              },
+              "reverse": {
+                "analyzer": "reverse",
+                "type": "text"
+              },
+              "trigram": {
+                "analyzer": "trigram",
+                "type": "text"
+              }
+            },
+            "term_vector": "with_positions_offsets",
+            "type": "text"
+          }
+        },
+        "type": "nested"
+      },
       "name": {
         "copy_to": [
           "_all_fields",
@@ -106,6 +141,16 @@
           }
         },
         "type": "nested"
+      },
+      "_author_ids": {
+        "analyzer": "keyword",
+        "term_vector": "yes",
+        "type": "text"
+      },
+      "_authors": {
+        "store": true,
+        "term_vector": "with_positions_offsets",
+        "type": "text"
       },
       "_sayt": {
         "type": "search_as_you_type"


### PR DESCRIPTION
This ES mapping update fixes askReco search (i.e. search-as-you-type SAYT) for research projects. 

Relates to https://gitlab.switch.ch/connectome/development-mvp/connectome-api/-/issues/22