### PR TITLE
Article Shape: Extend Less Than Constraint to Include Equality

### DIFF
--- a/shapes/article/schema.json
+++ b/shapes/article/schema.json
@@ -56,7 +56,9 @@
                   "datatype": "xsd:integer"
                 }
               ],
-              "lessThan": "schema:pageEnd",
+              "http://www.w3.org/ns/shacl#lessThanOrEquals": {
+                "@id": "schema:pageEnd"
+              },
               "maxCount": 1
             }
           ]

--- a/shapes/article/schema.json
+++ b/shapes/article/schema.json
@@ -56,9 +56,6 @@
                   "datatype": "xsd:integer"
                 }
               ],
-              "http://www.w3.org/ns/shacl#lessThanOrEquals": {
-                "@id": "schema:pageEnd"
-              },
               "maxCount": 1
             }
           ]


### PR DESCRIPTION
~~Page start and end could also be qual if the length of an article is 1one.~~

~~Due to a missing definition of `sh:lessThanOrEquals` (https://www.w3.org/TR/shacl/#LessThanOrEqualsConstraintComponent) in https://incf.github.io/neuroshapes/contexts/schema.json, the IRI is fully written in the shapes definition.~~